### PR TITLE
Add tabs and global styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Aplicación web moderna para control de gastos personales usando Next.js y Fireb
 - `npm run dev`
 
 ## Estructura
+- `/src/app`
 - `/src/components`
+- `/src/components/Tabs.tsx` define una navegación en pestañas
 - `/src/hooks`
 - `/src/services`
+- `/src/app/globals.css` contiene estilos globales
 
 Importa este repositorio en GitHub Codespaces o ejecútalo localmente.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,55 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 2rem;
+}
+
+.tab-list {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 1rem;
+}
+
+.tab-list button {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+
+.tab-list button.active {
+  border-color: #0070f3;
+  font-weight: bold;
+}
+
+.tab-panel {
+  padding: 1rem 0;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  opacity: 0.9;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Personal Expense App',
+  description: 'Gestiona tus gastos personales',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,28 @@
+import { BankForm } from '../components/Banks/BankForm';
+import { BankList } from '../components/Banks/BankList';
+import { Tabs, Tab } from '../components/Tabs';
+
+export default function Home() {
+  const tabs: Tab[] = [
+    {
+      label: 'Bancos',
+      content: (
+        <>
+          <BankForm />
+          <BankList />
+        </>
+      ),
+    },
+    {
+      label: 'Resumen',
+      content: <p>Próximamente...</p>,
+    },
+  ];
+
+  return (
+    <main>
+      <h1>Personal Expense App</h1>
+      <Tabs tabs={tabs} />
+    </main>
+  );
+}

--- a/src/components/Banks/BankForm.tsx
+++ b/src/components/Banks/BankForm.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState } from 'react';
 import { useBanks } from '../../hooks/useBanks';
 

--- a/src/components/Banks/BankList.tsx
+++ b/src/components/Banks/BankList.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { useBanks } from '../../hooks/useBanks';
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React, { ReactNode, useState } from 'react';
+
+export interface Tab {
+  label: string;
+  content: ReactNode;
+}
+
+export function Tabs({ tabs }: { tabs: Tab[] }) {
+  const [active, setActive] = useState(0);
+
+  return (
+    <div>
+      <div className="tab-list">
+        {tabs.map((tab, idx) => (
+          <button
+            key={idx}
+            className={active === idx ? 'active' : ''}
+            onClick={() => setActive(idx)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="tab-panel">{tabs[active].content}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- style app with `globals.css`
- set up root layout to include global styles
- add `Tabs` component for navigation
- mark bank components as client components
- show banks form and list inside tabs
- update README with new structure

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839fa549d308321a352e3708f703343