### PR TITLE
Add tab navigation and global styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ Aplicación web moderna para control de gastos personales usando Next.js y Fireb
 - `npm run dev`
 
 ## Estructura
+- `/src/app`
 - `/src/components`
 - `/src/hooks`
 - `/src/services`
+
+### Nuevos archivos
+- `src/app/globals.css`: estilos globales sencillos
+- `src/components/Tabs.tsx`: componente de pestañas reutilizable
 
 Importa este repositorio en GitHub Codespaces o ejecútalo localmente.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 2rem;
+}
+
+.tabs {
+  margin-top: 1rem;
+}
+
+.tab-buttons button {
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+}
+
+.tab-buttons button.active {
+  font-weight: bold;
+}
+
+form input {
+  margin-right: 0.5rem;
+  padding: 0.25rem;
+}
+
+form button {
+  padding: 0.25rem 0.75rem;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Personal Expense App',
+  description: 'Gestiona tus gastos personales',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,27 @@
+import { BankForm } from '../components/Banks/BankForm';
+import { BankList } from '../components/Banks/BankList';
+import { Tabs, Tab } from '../components/Tabs';
+
+export default function Home() {
+  const tabs: Tab[] = [
+    {
+      label: 'Bancos',
+      content: (
+        <>
+          <BankForm />
+          <BankList />
+        </>
+      ),
+    },
+    {
+      label: 'Resumen',
+      content: <p>En construcción...</p>,
+    },
+  ];
+  return (
+    <main>
+      <h1>Personal Expense App</h1>
+      <Tabs tabs={tabs} />
+    </main>
+  );
+}

--- a/src/components/Banks/BankForm.tsx
+++ b/src/components/Banks/BankForm.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState } from 'react';
 import { useBanks } from '../../hooks/useBanks';
 

--- a/src/components/Banks/BankList.tsx
+++ b/src/components/Banks/BankList.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { useBanks } from '../../hooks/useBanks';
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useState, ReactNode } from 'react';
+
+export interface Tab {
+  label: string;
+  content: ReactNode;
+}
+
+export function Tabs({ tabs }: { tabs: Tab[] }) {
+  const [active, setActive] = useState(0);
+
+  return (
+    <div className="tabs">
+      <div className="tab-buttons">
+        {tabs.map((t, i) => (
+          <button
+            key={t.label}
+            className={i === active ? 'active' : ''}
+            onClick={() => setActive(i)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="tab-content">{tabs[active]?.content}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a simple `Tabs` component with client-side state
- add global stylesheet and import it from the root layout
- use tabs on the home page to switch between banks and a placeholder "Resumen"
- mark bank components as client components
- document new files in README

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839fa549d308321a352e3708f703343